### PR TITLE
ADD :force_quote option to quote all non-NULL data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,23 @@ PgCsv.new(opts).export(to, opts)
 
 Options:
 ``` ruby
-:sql        => "select p.* from users u, projects p where p.user_id = u.id order by email limit 10"
-:connection => AR.connection
-:delimiter  => ["\t", ",", ]
-:header     => boolean, use pg header for fields?
-:logger     => logger
-:columns    => array of column names, ignore :header option
-:encoding   => encoding (default is pg_default), list of encodings: http://www.postgresql.org/docs/8.4/static/multibyte.html#CHARSET-TABLE
+:sql         => "select p.* from users u, projects p where p.user_id = u.id order by email limit 10"
+:connection  => AR.connection
+:delimiter   => ["\t", ",", ]
+:header      => boolean, use pg header for fields?
+:logger      => logger
+:columns     => array of column names, ignore :header option
+:encoding    => encoding (default is pg_default), list of encodings: http://www.postgresql.org/docs/8.4/static/multibyte.html#CHARSET-TABLE
+:force_quote => boolean, force quotes around all non-NULL data?
 
-:temp_file  => boolean, generate throught temp file? final file appears by mv
-:temp_dir   => for :temp_file, ex: '/tmp'
+:temp_file   => boolean, generate throught temp file? final file appears by mv
+:temp_dir    => for :temp_file, ex: '/tmp'
 
-:type       => :plain - return full string
-            => :gzip  - save file to gzip
-            => :stream - save to stream
-            => :file - just save to file = default
-            => :yield - return each row to block
+:type        => :plain - return full string
+             => :gzip  - save file to gzip
+             => :stream - save to stream
+             => :file - just save to file = default
+             => :yield - return each row to block
 ```
 
 Examples:

--- a/lib/pg_csv.rb
+++ b/lib/pg_csv.rb
@@ -133,7 +133,7 @@ class PgCsv
   ) TO STDOUT
   WITH CSV
   DELIMITER '#{delimiter}'
-  #{use_pg_header? ? 'HEADER' : ''} #{encoding ? "ENCODING '#{encoding}'" : ''}
+  #{use_pg_header? ? 'HEADER' : ''} #{encoding ? "ENCODING '#{encoding}'" : ''} #{force_quote ? "FORCE QUOTE *" : ''}
       SQL
     end
 
@@ -192,6 +192,10 @@ class PgCsv
 
     def encoding
       o(:encoding)
+    end
+
+    def force_quote
+      o(:force_quote)
     end
   end
 

--- a/spec/pg_csv_spec.rb
+++ b/spec/pg_csv_spec.rb
@@ -63,6 +63,18 @@ describe PgCsv do
       end
     end
 
+    describe "force_quote" do
+      it "force_quote" do
+        PgCsv.new(:sql => @sql).export(@name, :force_quote => true)
+        with_file(@name){|d| d.should == "\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n"}
+      end
+
+      it "with headers" do
+        PgCsv.new(:sql => @sql).export(@name, :header => true, :force_quote => true)
+        with_file(@name){|d| d.should == "a,b,c\n\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n"}
+      end
+    end
+
   end
 
   describe "moving options no matter" do


### PR DESCRIPTION
The `COPY TO` feature in PostgreSQL has an option called `FORCE QUOTE`.
It will cause the resulting non-NULL CSV data to be wrapped inside of
the character set from the `QUOTE` option.