### PR TITLE
Update pg gem version to ~> 1.0.0

### DIFF
--- a/pg_csv.gemspec
+++ b/pg_csv.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
-  s.add_dependency "pg", '~> 0.17'
+  s.add_dependency "pg", '~> 1.0.0'
   s.add_development_dependency "rspec", '<3'
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord"


### PR DESCRIPTION
Updates pg dependency to expect 1.0.0 or greater

pg 1.0.0 was released 1/10/2018
https://rubygems.org/gems/pg/versions/1.0.0