### PR TITLE
Upgrade pg and rspec gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,28 @@ Options:
 
 Examples:
 ``` ruby
-PgCsv.new(:sql => sql).export('a1.csv')
-PgCsv.new(:sql => sql).export('a2.gz', :type => :gzip)
-PgCsv.new(:sql => sql).export('a3.csv', :temp_file => true)
-PgCsv.new(:sql => sql, :type => :plain).export
-File.open("a4.csv", 'a'){|f| PgCsv.new(:sql => "select * from users").\
-    export(f, :type => :stream) }
-PgCsv.new(:sql => sql).export('a5.csv', :delimiter => "\t")
-PgCsv.new(:sql => sql).export('a6.csv', :header => true)
-PgCsv.new(:sql => sql).export('a7.csv', :columns => %w{id a b c})
-PgCsv.new(:sql => sql, :connection => SomeDb.connection, :columns => %w{id a b c}, :delimiter => "|").\
-    export('a8.gz', :type => :gzip, :temp_file => true)
+PgCsv.new(sql: sql).export('a1.csv')
+PgCsv.new(sql: sql).export('a2.gz', type: :gzip)
+PgCsv.new(sql: sql).export('a3.csv', temp_file: true)
+PgCsv.new(sql: sql, type: :plain).export
+File.open("a4.csv", 'a'){ |f| PgCsv.new(sql: "select * from users").\
+    export(f, type: :stream) }
+PgCsv.new(sql: sql).export('a5.csv', delimiter: "\t")
+PgCsv.new(sql: sql).export('a6.csv', header: true)
+PgCsv.new(sql: sql).export('a7.csv', columns: %w(id a b c))
+PgCsv.new(sql: sql, connection: SomeDb.connection, columns: %w(id a b c), delimiter: "|").\
+    export('a8.gz', type: :gzip, temp_file: true)
 
 # example collect from shards
 Zlib::GzipWriter.open('some.gz') do |stream|
-  e = PgCsv.new(:sql => sql, :type => :stream)
+  e = PgCsv.new(sql: sql, type: :stream)
   ConnectionPool.each_shard do |connection|
-    e.export(stream, :connection => connection)
+    e.export(stream, connection: connection)
   end
 end
 
 # yield example
-PgCsv.new(:sql => sql, :type => :yield).export do |row|
+PgCsv.new(sql: sql, type: :yield).export do |row|
   puts row
 end
 ```

--- a/pg_csv.gemspec
+++ b/pg_csv.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
-  s.add_dependency "pg", '~> 1.2.3'
+  s.add_dependency "pg"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord"

--- a/pg_csv.gemspec
+++ b/pg_csv.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
-  s.add_dependency "pg", '~> 0.17'
-  s.add_development_dependency "rspec", '<3'
+  s.add_dependency "pg", '~> 1.2.3'
+  s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord"
+  s.add_development_dependency "byebug"
 end

--- a/spec/pg_csv_spec.rb
+++ b/spec/pg_csv_spec.rb
@@ -1,12 +1,13 @@
 # encoding: utf-8
+
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe PgCsv do
 
   before :each do
     Test.delete_all
-    Test.create :a => 1, :b => 2, :c => 3
-    Test.create :a => 4, :b => 5, :c => 6
+    Test.create a: 1, b: 2, c: 3
+    Test.create a: 4, b: 5, c: 6
 
     @name = tmp_dir + "1.csv"
     FileUtils.rm(@name) rescue nil
@@ -22,171 +23,173 @@ describe PgCsv do
   describe "simple export" do
 
     it "1" do
-      PgCsv.new(:sql => @sql0).export(@name)
-      with_file(@name){|d| d.should == "1,2,3\n4,5,6\n" }
+      PgCsv.new(sql: @sql0).export(@name)
+      with_file(@name){ |d| expect(d).to eq("1,2,3\n4,5,6\n")}
     end
 
     it "2" do
-      PgCsv.new(:sql => @sql).export(@name)
-      with_file(@name){|d| d.should == "4,5,6\n1,2,3\n" }
+      PgCsv.new(sql: @sql).export(@name)
+      with_file(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n") }
     end
 
     it "delimiter" do
-      PgCsv.new(:sql => @sql).export(@name, :delimiter => "|")
-      with_file(@name){|d| d.should == "4|5|6\n1|2|3\n" }
+      PgCsv.new(sql: @sql).export(@name, delimiter: "|")
+      with_file(@name){ |d| expect(d).to eq("4|5|6\n1|2|3\n") }
     end
 
     it "encoding" do
-      Test.create! :a => 2, :b => 3, :c => 4, :d => "абсд"
+      Test.create!(a: 2, b: 3, c: 4, d: "абсд")
 
-      PgCsv.new(:sql => "select d from tests where a = 2").export(@name, :encoding => "WIN1251")
-      with_file(@name){|d| d.force_encoding('cp1251').should == "абсд\n".encode('cp1251') }
+      PgCsv.new(sql: "select d from tests where a = 2").export(@name, encoding: "WIN1251")
+      with_file(@name){ |d| expect(d.force_encoding('cp1251')).to eq("абсд\n".encode('cp1251')) }
     end
 
     describe "headers" do
       it "header" do
-        PgCsv.new(:sql => @sql).export(@name, :header => true)
-        with_file(@name){|d| d.should == "a,b,c\n4,5,6\n1,2,3\n" }
+        PgCsv.new(sql: @sql).export(@name, header: true)
+        with_file(@name){ |d| expect(d).to eq("a,b,c\n4,5,6\n1,2,3\n") }
       end
 
       it "columns" do
-        PgCsv.new(:sql => @sql).export(@name, :columns => %w(q w e))
-        with_file(@name){|d| d.should == "q,w,e\n4,5,6\n1,2,3\n" }
+        PgCsv.new(sql: @sql).export(@name, columns: %w(q w e))
+        with_file(@name){ |d| expect(d).to eq("q,w,e\n4,5,6\n1,2,3\n") }
       end
 
       it "columns with header" do
-        PgCsv.new(:sql => @sql).export(@name, :header => true, :columns => %w(q w e))
+        PgCsv.new(sql: @sql).export(@name, header: true, columns: %w(q w e))
 
         with_file(@name) do |d|
-          d.should == "q,w,e\n4,5,6\n1,2,3\n"
+          expect(d).to eq("q,w,e\n4,5,6\n1,2,3\n")
         end
       end
     end
 
     describe "force_quote" do
       it "force_quote" do
-        PgCsv.new(:sql => @sql).export(@name, :force_quote => true)
-        with_file(@name){|d| d.should == "\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n"}
+        PgCsv.new(sql: @sql).export(@name, force_quote: true)
+        with_file(@name){ |d| expect(d).to eq("\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n") }
       end
 
       it "with headers" do
-        PgCsv.new(:sql => @sql).export(@name, :header => true, :force_quote => true)
-        with_file(@name){|d| d.should == "a,b,c\n\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n"}
+        PgCsv.new(sql: @sql).export(@name, header: true, force_quote: true)
+        with_file(@name){ |d| expect(d).to eq("a,b,c\n\"4\",\"5\",\"6\"\n\"1\",\"2\",\"3\"\n") }
       end
     end
-
   end
 
   describe "moving options no matter" do
     it "1" do
-      PgCsv.new(:sql => @sql).export(@name, :delimiter => "|")
-      with_file(@name){|d| d.should == "4|5|6\n1|2|3\n" }
+      PgCsv.new(sql: @sql).export(@name, delimiter: "|")
+      with_file(@name){ |d| expect(d).to eq("4|5|6\n1|2|3\n") }
     end
 
     it "2" do
-      PgCsv.new(:delimiter => "|").export(@name, :sql => @sql)
-      with_file(@name){|d| d.should == "4|5|6\n1|2|3\n"}
+      PgCsv.new(delimiter: "|").export(@name, sql: @sql)
+      with_file(@name){ |d| expect(d).to eq("4|5|6\n1|2|3\n") }
     end
   end
 
   describe "local options dont recover global" do
     it "test" do
-      e = PgCsv.new(:sql => @sql, :delimiter => "*")
-      e.export(@name, :delimiter => "|")
-      with_file(@name){|d| d.should == "4|5|6\n1|2|3\n" }
+      e = PgCsv.new(sql: @sql, delimiter: "*")
+      e.export(@name, delimiter: "|")
+      with_file(@name){ |d| expect(d).to eq("4|5|6\n1|2|3\n") }
 
       e.export(@name)
-      with_file(@name){|d| d.should == "4*5*6\n1*2*3\n" }
+      with_file(@name){ |d| expect(d).to eq("4*5*6\n1*2*3\n") }
     end
   end
 
   describe "using temp file" do
     it "at least file should return to target and set correct chmod" do
-      File.exists?(@name).should == false
-      PgCsv.new(:sql => @sql, :temp_file => true, :temp_dir => tmp_dir).export(@name)
-      with_file(@name){|d| d.should == "4,5,6\n1,2,3\n" }
-      sprintf("%o", File.stat(@name).mode).to_i.should >= 100644
+      expect(File).not_to exist(@name)
+      PgCsv.new(sql: @sql, temp_file: true, temp_dir: tmp_dir).export(@name)
+      with_file(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n") }
+      expect(sprintf("%o", File.stat(@name).mode).to_i).to eq(100644)
     end
 
     it "same with gzip" do
-      File.exists?(@name).should == false
-      PgCsv.new(:sql => @sql, :temp_file => true, :temp_dir => tmp_dir, :type => :gzip).export(@name)
-      with_gzfile(@name){|d| d.should == "4,5,6\n1,2,3\n" }
-      sprintf("%o", File.stat(@name).mode).to_i.should >= 100644
+      expect(File).not_to exist(@name)
+      PgCsv.new(sql: @sql, temp_file: true, temp_dir: tmp_dir, type: :gzip).export(@name)
+      with_gzfile(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n") }
+      expect(sprintf("%o", File.stat(@name).mode).to_i).to eq(100644)
     end
   end
 
   describe "different types of export" do
     it "gzip export" do
-      File.exists?(@name).should == false
-      PgCsv.new(:sql => @sql, :type => :gzip).export(@name)
-      with_gzfile(@name){|d| d.should == "4,5,6\n1,2,3\n" }
-      sprintf("%o", File.stat(@name).mode).to_i.should >= 100644
+      expect(File).not_to exist(@name)
+      PgCsv.new(sql: @sql, type: :gzip).export(@name)
+      with_gzfile(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n") }
+      expect(sprintf("%o", File.stat(@name).mode).to_i).to eq(100644)
     end
 
     it "plain export" do
-      PgCsv.new(:sql => @sql, :type => :plain).export.should == "4,5,6\n1,2,3\n"
+      expect(PgCsv.new(sql: @sql, type: :plain).export).to eq("4,5,6\n1,2,3\n")
     end
 
     it "custom stream" do
-      ex = PgCsv.new(:sql => @sql, :type => :stream)
+      ex = PgCsv.new(sql: @sql, type: :stream)
       File.open(@name, 'w') do |stream|
         ex.export(stream)
-        ex.export(stream, :sql => @sql0)
+        ex.export(stream, sql: @sql0)
       end
 
-      with_file(@name){|d| d.should == "4,5,6\n1,2,3\n1,2,3\n4,5,6\n" }
+      with_file(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n1,2,3\n4,5,6\n") }
     end
 
     it "file as default" do
-      PgCsv.new(:sql => @sql, :type => :file).export(@name)
-      with_file(@name){|d| d.should == "4,5,6\n1,2,3\n" }
-      sprintf("%o", File.stat(@name).mode).to_i.should >= 100644
+      PgCsv.new(sql: @sql, type: :file).export(@name)
+      with_file(@name){ |d| expect(d).to eq("4,5,6\n1,2,3\n") }
+      expect(sprintf("%o", File.stat(@name).mode).to_i).to eq(100644)
     end
 
     it "yield export" do
       rows = []
-      PgCsv.new(:sql => @sql, :type => :yield).export do |row|
-        rows << row
-      end.should == 2
+      expect(
+        PgCsv.new(sql: @sql, type: :yield).export { |row| rows << row }
+      ).to eq(2)
 
-      rows.should == ["4,5,6\n", "1,2,3\n"]
+      expect(rows).to eq(["4,5,6\n", "1,2,3\n"])
     end
   end
 
   describe "integration specs" do
     it "1" do
-      File.exists?(@name).should == false
-      PgCsv.new(:sql => @sql, :type => :gzip).export(@name, :delimiter => "|", :columns => %w{q w e}, :temp_file => true, :temp_dir => tmp_dir)
-      with_gzfile(@name){|d| d.should == "q|w|e\n4|5|6\n1|2|3\n" }
+      expect(File).not_to exist(@name)
+      PgCsv.new(sql: @sql, type: :gzip).export(
+        @name, delimiter: "|", columns: %w(q w e), temp_file: true, temp_dir: tmp_dir
+      )
+      with_gzfile(@name){ |d| expect(d).to eq("q|w|e\n4|5|6\n1|2|3\n") }
     end
 
     it "2" do
       Zlib::GzipWriter.open(@name) do |gz|
-        e = PgCsv.new(:sql => @sql, :type => :stream)
+        e = PgCsv.new(sql: @sql, type: :stream)
 
-        e.export(gz, :delimiter => "|", :columns => %w{q w e} )
-        e.export(gz, :delimiter => "*", :sql => @sql0)
+        e.export(gz, delimiter: "|", columns: %w(q w e) )
+        e.export(gz, delimiter: "*", sql: @sql0)
       end
 
-      with_gzfile(@name){|d| d.should == "q|w|e\n4|5|6\n1|2|3\n1*2*3\n4*5*6\n" }
+      with_gzfile(@name){ |d| expect(d).to eq("q|w|e\n4|5|6\n1|2|3\n1*2*3\n4*5*6\n") }
     end
 
     it "gzip with empty content" do
-      File.exists?(@name).should == false
-      PgCsv.new(:sql => "select a,b,c from tests where a = -1", :type => :gzip).export(@name, :temp_file => true, :temp_dir => tmp_dir)
-      with_gzfile(@name){|d| d.should == "" }
+      expect(File).not_to exist(@name)
+      PgCsv.new(sql: "select a,b,c from tests where a = -1", type: :gzip).export(
+        @name, temp_file: true, temp_dir: tmp_dir
+      )
+      with_gzfile(@name){ |d| expect(d).to be_empty }
     end
   end
 
   it "custom row proc" do
-    e = PgCsv.new(:sql => @sql)
+    e = PgCsv.new(sql: @sql)
 
     e.export(@name) do |row|
       row.split(",").join("-|-")
     end
 
-    with_file(@name){|d| d.should == "4-|-5-|-6\n1-|-2-|-3\n" }
+    with_file(@name){ |d| expect(d).to eq("4-|-5-|-6\n1-|-2-|-3\n") }
   end
-
 end

--- a/spec/spec_support.rb
+++ b/spec/spec_support.rb
@@ -1,7 +1,11 @@
 require 'fileutils'
 require 'active_record'
 
-conn = {'adapter' => 'postgresql', 'database' => 'pgcsv_test', :encoding => "unicode"}
+conn = {
+  adapter: 'postgresql',
+  database: 'pgcsv_test',
+  encoding: "unicode"
+}
 ActiveRecord::Base.establish_connection conn
 
 class Test < ActiveRecord::Base
@@ -29,7 +33,7 @@ def tmp_dir
 end
 
 def with_file(name)
-  File.exists?(name).should == true
+  expect(File).to exist(name)
   q = 1
   File.open(name) do |file|
     data = file.read
@@ -37,16 +41,17 @@ def with_file(name)
     q = 2
   end
 
-  q.should == 2
+  expect(q).to eq(2)
 end
 
 def with_gzfile(name)
-  File.exist?(name).should == true
+  expect(File).to exist(name)
   q = 1
   Zlib::GzipReader.open(name) do |gz|
     data = gz.read
     yield data
     q = 2
   end
-  q.should == 2
+
+  expect(q).to eq(2)
 end


### PR DESCRIPTION
# Problem
Previously pg_csv gem introduced a restriction of gem `pg` in my project to be limited with version 0.17. This though is rather old version for now. 

# Solution
1. Upgraded the pg-version requirement in this gem
2. Upgraded rspec-gem
3. Updated some rspec syntax
4. Updated old ruby hashrocket notation
5. Added development dependency of byebug gem to more easily trace spec issues